### PR TITLE
fix gcc15 build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,5 +8,5 @@ add_executable(localsend
 	recv.cpp
 	selfcert.cpp
 )
-target_link_libraries(localsend ssl crypto pthread magic curl)
+target_link_libraries(localsend ssl crypto pthread magic curl cpp-httplib)
 install(TARGETS localsend DESTINATION bin)

--- a/src/global.h
+++ b/src/global.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <atomic>
 extern std::atomic<bool> run;
 extern std::map<std::string, nlohmann::json> clients;
 extern const int PORT;

--- a/src/recv.cpp
+++ b/src/recv.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <fstream>
 #include <nlohmann/json.hpp>
 #include <random>
 #include <thread>

--- a/src/send.h
+++ b/src/send.h
@@ -1,6 +1,7 @@
 
 #ifndef SEND_H
 #define SEND_H
+#include <string>
 #include <vector>
 
 void send(const std::vector<std::string> &files);


### PR DESCRIPTION
Fix gcc 15 build.
```
localsend-bsd/src/send.h:6:34: error: ‘string’ is not a member of ‘std’
    6 | void send(const std::vector<std::string> &files);
      |                                  ^~~~~~
localsend-bsd/src/send.h:5:1: note: ‘std::string’ is defined in header ‘<string>’; this is probably fixable by adding ‘#include <string>’
    4 | #include <vector>
  +++ |+#include <string>
    5 | 
localsend-bsd/src/send.h:6:40: error: template argument 1 is invalid
    6 | void send(const std::vector<std::string> &files);
      |                                        ^
localsend-bsd/src/send.h:6:40: error: template argument 2 is invalid
localsend-bsd/src/global.cpp:3:19: error: aggregate ‘std::atomic<bool> run’ has incomplete type and cannot be defined
    3 | std::atomic<bool> run;
      |                   ^~~
localsend-bsd/src/global.cpp:2:1: note: ‘std::atomic’ is defined in header ‘<atomic>’; this is probably fixable by adding ‘#include <atomic>’
    1 | #include "global.h"
  +++ |+#include <atomic>
    2 | 
In file included from localsend-bsd/src/send.cpp:14:
localsend-bsd/src/global.h: In function ‘void send(const std::vector<std::__cxx11::basic_string<char>, std::allocator<std::__cxx11::basic_string<char> > 
>&)’:
localsend-bsd/src/global.h:7:26: error: ‘run’ has incomplete type
    7 | extern std::atomic<bool> run;
      |                          ^~~
In file included from /usr/include/c++/15.1.1/bits/shared_ptr_atomic.h:33,
                 from /usr/include/c++/15.1.1/memory:83,
                 from /usr/include/nlohmann/json.hpp:29,
                 from localsend-bsd/src/send.cpp:10:
/usr/include/c++/15.1.1/bits/atomic_base.h:173:12: note: declaration of ‘struct std::atomic<bool>’
  173 |     struct atomic;
      |            ^~~~~~
localsend-bsd/src/global.h:7:26: error: ‘run’ has incomplete type
    7 | extern std::atomic<bool> run;
      |                          ^~~
/usr/include/c++/15.1.1/bits/atomic_base.h:173:12: note: declaration of ‘struct std::atomic<bool>’
  173 |     struct atomic;
      |            ^~~~~~
localsend-bsd/src/recv.cpp: In function ‘void handleupload(const httplib::Request&, httplib::Response&, const httplib::ContentReader&, const std::string&
)’:
localsend-bsd/src/recv.cpp:102:31: error: variable ‘std::ofstream outfile’ has initializer but incomplete type
  102 |         std::ofstream outfile(savedir + "/" + filename, std::ios::binary);
      |                               ^~~~~~~
localsend-bsd/src/recv.cpp:17:1: note: ‘std::ofstream’ is defined in header ‘<fstream>’; this is probably fixable by adding ‘#include <fstream>’
   16 | #include "udp.h"
  +++ |+#include <fstream>
   17 | nlohmann::json uploadsessions;
```

```
/usr/bin/ld: CMakeFiles/localsend.dir/recv.cpp.o: in function `handleupload(httplib::Request const&, httplib::Response&, httplib::ContentReader const&, std::__cxx11::
basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
recv.cpp:(.text+0x7a6): undefined reference to `httplib::Request::get_param_value(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > cons
t&, unsigned long) const'
/usr/bin/ld: recv.cpp:(.text+0x84a): undefined reference to `httplib::Request::get_param_value(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator
<char> > const&, unsigned long) const'
/usr/bin/ld: recv.cpp:(.text+0x92d): undefined reference to `httplib::Request::get_param_value(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator
<char> > const&, unsigned long) const'
/usr/bin/ld: recv.cpp:(.text+0x13d1): undefined reference to `httplib::Response::set_content(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<c
har> >&&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: CMakeFiles/localsend.dir/recv.cpp.o: in function `handleprepareupload(httplib::Request const&, httplib::Response&)':
recv.cpp:(.text+0x2399): undefined reference to `httplib::Response::set_content(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, std
::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: CMakeFiles/localsend.dir/recv.cpp.o: in function `start_recv(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
recv.cpp:(.text+0x2b09): undefined reference to `httplib::SSLServer::SSLServer(char const*, char const*, char const*, char const*, char const*)'
/usr/bin/ld: recv.cpp:(.text+0x2b72): undefined reference to `httplib::Server::Post(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > co
nst&, std::function<void (httplib::Request const&, httplib::Response&)>)'
/usr/bin/ld: recv.cpp:(.text+0x2c22): undefined reference to `httplib::Server::Post(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > co
nst&, std::function<void (httplib::Request const&, httplib::Response&, httplib::ContentReader const&)>)'
/usr/bin/ld: recv.cpp:(.text+0x2cda): undefined reference to `httplib::Server::listen(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > 
const&, int, int)'
/usr/bin/ld: recv.cpp:(.text+0x2d22): undefined reference to `httplib::SSLServer::~SSLServer()'
/usr/bin/ld: recv.cpp:(.text+0x2f17): undefined reference to `httplib::SSLServer::~SSLServer()'
```
